### PR TITLE
feat: drupal 11 support

### DIFF
--- a/localgov_login_redirect.info.yml
+++ b/localgov_login_redirect.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Login Redirect
 description: Simple module to redirect users at login.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.2 || ^11
 
 configure: localgov_login_redirect.settings
 dependencies:

--- a/localgov_login_redirect.info.yml
+++ b/localgov_login_redirect.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Login Redirect
 description: Simple module to redirect users at login.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 
 configure: localgov_login_redirect.settings
 dependencies:

--- a/src/Form/LoginRedirectSettingsForm.php
+++ b/src/Form/LoginRedirectSettingsForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\localgov_login_redirect\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Path\PathValidator;
@@ -25,11 +26,13 @@ class LoginRedirectSettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config_manager
+   *   The typed config manager.
    * @param \Drupal\Core\Path\PathValidator $path_validator
    *   The route provider.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, PathValidator $path_validator) {
-    parent::__construct($config_factory);
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typed_config_manager, PathValidator $path_validator) {
+    parent::__construct($config_factory, $typed_config_manager);
     $this->pathValidator = $path_validator;
   }
 
@@ -39,6 +42,7 @@ class LoginRedirectSettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('path.validator')
     );
   }


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds D11 support, the bump to 10.2 minimum is for https://www.drupal.org/node/3404140

Errors are related to PHP 8.4 and contrib modules.